### PR TITLE
fix dpkg error creating symbolic link `/usr/share/man/man1/psql.1.gz.…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN mkdir /app && \
     groupadd --gid 10001 app && \
     useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
 
+# hack to make postgresql-client install work on slim
+RUN mkdir -p /usr/share/man/man1 \
+    && mkdir -p /usr/share/man/man7
+
 # install a few essentials and clean apt caches afterwards
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
…dpkg-tmp': No such file or directory

For postgresql-client install since the slim image removes the man page folders

This was a problem :garndt was seeing and I reproduced after cleaning out my cached images.

Similar to:

https://github.com/dalibo/temboard/issues/211
https://github.com/debuerreotype/debuerreotype/issues/10

so I adopted the fix from dalibo/temboard