### PR TITLE
Add cors

### DIFF
--- a/relops_hardware_controller/api/decorators.py
+++ b/relops_hardware_controller/api/decorators.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from functools import wraps
+
+
+def set_cors_headers(origin=None, methods='GET'):
+    """Decorator function that sets CORS headers on the response."""
+    if isinstance(methods, str):
+        methods = [methods]
+
+    def decorator(func):
+
+        @wraps(func)
+        def inner(*args, **kwargs):
+            response = func(*args, **kwargs)
+            response['Access-Control-Allow-Origin'] = origin
+            response['Access-Control-Allow-Methods'] = ','.join(methods)
+            return response
+
+        return inner
+
+    return decorator

--- a/relops_hardware_controller/api/urls.py
+++ b/relops_hardware_controller/api/urls.py
@@ -8,6 +8,6 @@ from . import views
 
 
 urlpatterns = [
-    url(r'^workers/(?P<worker_id>[-_0-9a-zA-Z]{1,128})/group/(?P<worker_group>[-_0-9a-zA-Z]{1,128})/jobs$', views.JobList.as_view(), name='JobList'),
+    url(r'^workers/(?P<worker_id>[-_0-9a-zA-Z]{1,128})/group/(?P<worker_group>[-_0-9a-zA-Z]{1,128})/jobs$', views.queue_job, name='JobList'),
     url(r'^jobs/(?P<pk>[0-9a-f]{8}\-[0-9a-f]{4}\-4[0-9a-f]{3}\-[89ab][0-9a-f]{3}\-[0-9a-f]{12})$', views.JobDetail.as_view(), name='JobDetail'),
 ]

--- a/relops_hardware_controller/api/views.py
+++ b/relops_hardware_controller/api/views.py
@@ -7,16 +7,18 @@ import logging
 from uuid import UUID
 
 import django.http
-from rest_framework import (
-    status,
-)
 from django.conf import settings
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes, authentication_classes, renderer_classes
+from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from .authentication import TaskclusterAuthentication
 from ..celery import celery_call_command
+from .decorators import set_cors_headers
 from .permissions import HasTaskclusterScopes
 from .models import Job, Machine, TaskClusterWorker
 from .serializers import (
@@ -28,62 +30,69 @@ from .serializers import (
 logger = logging.getLogger(__name__)
 
 
-class JobList(APIView):
-    """
-    Create a new job to queue it.
-    """
-    authentication_classes = (
-        TaskclusterAuthentication,
+@csrf_exempt
+@set_cors_headers(origin=settings.CORS_ORIGIN, methods=['OPTIONS', 'POST'])
+@api_view(['OPTIONS', 'POST'])
+@renderer_classes((JSONRenderer,))
+def queue_job(request, worker_id, worker_group, format=None):
+    if request.method == 'OPTIONS':
+        return queue_job_options(request, worker_id, worker_group, format=None)
+    elif request.method == 'POST':
+        return queue_job_create(request, worker_id, worker_group, format=None)
+    else:
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+@api_view(['OPTIONS'])
+@renderer_classes((JSONRenderer,))
+def queue_job_options(request, worker_id, worker_group, format=None):
+    return Response({}, status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@permission_classes((IsAuthenticated, HasTaskclusterScopes,))
+@authentication_classes((TaskclusterAuthentication,))
+@renderer_classes((JSONRenderer,))
+def queue_job_create(request, worker_id, worker_group, format=None):
+    serializer = JobSerializer(data=dict(
+        worker_id=worker_id,
+        worker_group=worker_group,
+        task_name=request.GET.get('task_name', '')
+    ))
+
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    job_tc_worker_id = serializer.validated_data['worker_id']
+    tc_worker = TaskClusterWorker.objects.filter(tc_worker_id=job_tc_worker_id).first()
+    if not tc_worker:
+        logger.info('Failed to find TC worker id: %s' % job_tc_worker_id)
+        return Response(dict(tc_worker_id='TC worker with that ID not found.'),
+                        status=status.HTTP_404_NOT_FOUND)
+
+    logger.debug('Found TC worker id: %s' % tc_worker.id)
+    serializer.validated_data['tc_worker_id'] = tc_worker.id
+
+    machine = tc_worker.machines.first()
+    if not machine:
+        return Response(dict(tc_worker_id='Not managing hardware running that TC worker.'),
+                        status=status.HTTP_404_NOT_FOUND)
+    serializer.validated_data['machine_id'] = machine.id
+
+    result = celery_call_command.delay(
+        serializer.validated_data['task_name'],
+        TaskClusterWorkerSerializer(tc_worker).data,
+        MachineSerializer(machine).data,
     )
-    permission_classes = (
-        IsAuthenticated,
-        HasTaskclusterScopes,
-    )
-    required_taskcluster_scope_sets = settings.REQUIRED_TASKCLUSTER_SCOPE_SETS
+    logger.info('queued a {} task with id: {}'.format(serializer.validated_data['task_name'], result.id))
 
-    def post(self, request, worker_id, worker_group, format=None):
-        serializer = JobSerializer(data=dict(
-            worker_id=worker_id,
-            worker_group=worker_group,
-            task_name=request.GET.get('task_name', '')
-        ))
+    serializer.validated_data['task_id'] = result.id
+    serializer.save()
 
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-        job_tc_worker_id = serializer.validated_data['worker_id']
-        tc_worker = TaskClusterWorker.objects.filter(tc_worker_id=job_tc_worker_id).first()
-        if not tc_worker:
-            logger.info('Failed to find TC worker id: %s' % job_tc_worker_id)
-            return Response(dict(tc_worker_id='TC worker with that ID not found.'),
-                            status=status.HTTP_404_NOT_FOUND)
 
-        logger.debug('Found TC worker id: %s' % tc_worker.id)
-        serializer.validated_data['tc_worker_id'] = tc_worker.id
-
-        machine = tc_worker.machines.first()
-        if not machine:
-            return Response(dict(tc_worker_id='Not managing hardware running that TC worker.'),
-                            status=status.HTTP_404_NOT_FOUND)
-        serializer.validated_data['machine_id'] = machine.id
-
-        # STATUS_QUEUED = Job.TASK_STATUSES[0][0]
-        # duplicate_job = Job.objects.filter(status=STATUS_QUEUED,
-        #                                    task_name=serializer.validated_data['task_name']).first()
-        # if duplicate_job:
-        #     return Response(dict(task_name='Task already scheduled for that TC worker\'s machine.'), status=status.HTTP_409_CONFLICT)
-
-        result = celery_call_command.delay(
-            serializer.validated_data['task_name'],
-            TaskClusterWorkerSerializer(tc_worker).data,
-            MachineSerializer(machine).data,
-        )
-        logger.info('queued a {} task with id: {}'.format(serializer.validated_data['task_name'], result.id))
-
-        serializer.validated_data['task_id'] = result.id
-        serializer.save()
-
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+queue_job.required_taskcluster_scope_sets = settings.REQUIRED_TASKCLUSTER_SCOPE_SETS
 
 
 class JobDetail(APIView):

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -151,6 +151,13 @@ class Base(Configuration):
     # And a 10 minute hard timeout.
     CELERY_TASK_TIME_LIMIT = CELERY_TASK_SOFT_TIME_LIMIT * 2
 
+    REST_FRAMEWORK = {
+        'DEFAULT_RENDERER_CLASSES': (
+            'rest_framework.renderers.JSONRenderer',
+            'rest_framework.renderers.BrowsableAPIRenderer',
+        )
+    }
+
     TASK_NAMES = [
         # 'loan',
         'reboot',
@@ -158,6 +165,8 @@ class Base(Configuration):
         # 'return_loan',
         'ping',
     ]
+
+    CORS_ORIGIN = values.Value()
 
     REQUIRED_TASKCLUSTER_SCOPE_SETS = [
         [
@@ -169,15 +178,18 @@ class Base(Configuration):
 class Dev(Base):
     DEBUG = True
     ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+    CORS_ORIGIN = 'localhost'
 
 
 class Prod(Base):
     ALLOWED_HOSTS = ['tools.taskcluster.net']
+    CORS_ORIGIN = 'tools.taskcluster.net'
 
 
 class Test(Base):
     DEBUG = False
 
     ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+    CORS_ORIGIN = 'localhost'
 
     SECRET_KEY = values.Value('not-so-secret-after-all')

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+import pytest
+
+from django import http
+from django.test import RequestFactory
+
+from relops_hardware_controller.api import decorators
+
+
+def test_set_cors_headers(rf):
+
+    # Happy patch
+    @decorators.set_cors_headers(origin='*')
+    def view_function(request):
+        return http.HttpResponse('hello world')
+
+    request = rf.get('/')
+    response = view_function(request)
+    assert response['Access-Control-Allow-Origin'] == '*'
+    assert response['Access-Control-Allow-Methods'] == 'GET'
+
+    # Overrides
+    @decorators.set_cors_headers(origin='example.com', methods=['HEAD', 'GET'])
+    def view_function(request):
+        return http.HttpResponse('hello world')
+    response = view_function(request)
+    assert response['Access-Control-Allow-Origin'] == 'example.com'
+    assert response['Access-Control-Allow-Methods'] == 'HEAD,GET'


### PR DESCRIPTION
fixes #30 breaks #29 more

Changes:
* Marks queue job endpoints as CSRF exempt (for the options endpoint it doesn't matter since it doesn't change state and the POST endpoint requires a hawk auth header which includes a nonce that will behave like a csrf token)
* Add cors headers
* Add unauthed options endpoint for queue_job 
* Switch job queuing endpoint to function based API views