### PR TITLE
XenAPI reboot

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -9,6 +9,7 @@ DJANGO_SECRET_KEY=dontusethisinprod
 
 # When you use motocker, these just needs to be anything
 DJANGO_BUGZILLA_API_KEY=anything
+DJANGO_XEN_PASSWORD=anything_zen_password
 
 # Sentry is not used when doing local development.
 #SENTRY_DSN=....

--- a/relops_hardware_controller/XenAPI.py
+++ b/relops_hardware_controller/XenAPI.py
@@ -1,0 +1,264 @@
+# Copyright (c) Citrix Systems, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#  1) Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2) Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# --------------------------------------------------------------------
+# Parts of this file are based upon xmlrpclib.py, the XML-RPC client
+# interface included in the Python distribution.
+#
+# Copyright (c) 1999-2002 by Secret Labs AB
+# Copyright (c) 1999-2002 by Fredrik Lundh
+#
+# By obtaining, using, and/or copying this software and/or its
+# associated documentation, you agree that you have read, understood,
+# and will comply with the following terms and conditions:
+#
+# Permission to use, copy, modify, and distribute this software and
+# its associated documentation for any purpose and without fee is
+# hereby granted, provided that the above copyright notice appears in
+# all copies, and that both that copyright notice and this permission
+# notice appear in supporting documentation, and that the name of
+# Secret Labs AB or the author not be used in advertising or publicity
+# pertaining to distribution of the software without specific, written
+# prior permission.
+#
+# SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
+# TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT-
+# ABILITY AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+# --------------------------------------------------------------------
+
+import gettext
+import six.moves.xmlrpc_client as xmlrpclib
+import six.moves.http_client as httplib
+import socket
+import sys
+
+translation = gettext.translation('xen-xm', fallback = True)
+
+API_VERSION_1_1 = '1.1'
+API_VERSION_1_2 = '1.2'
+
+class Failure(Exception):
+    def __init__(self, details):
+        self.details = details
+
+    def __str__(self):
+        try:
+            return str(self.details)
+        except Exception as exn:
+            msg = "Xen-API failure: %s" % exn
+            sys.stderr.write(msg)
+            return msg
+
+    def _details_map(self):
+        return dict([(str(i), self.details[i])
+                     for i in range(len(self.details))])
+
+
+# Just a "constant" that we use to decide whether to retry the RPC
+_RECONNECT_AND_RETRY = object()
+
+class UDSHTTPConnection(httplib.HTTPConnection):
+    """HTTPConnection subclass to allow HTTP over Unix domain sockets. """
+    def connect(self):
+        path = self.host.replace("_", "/")
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(path)
+
+class UDSHTTP(httplib.HTTPConnection):
+    _connection_class = UDSHTTPConnection
+
+class UDSTransport(xmlrpclib.Transport):
+    def __init__(self, use_datetime=0):
+        self._use_datetime = use_datetime
+        self._extra_headers=[]
+        self._connection = (None, None)
+    def add_extra_header(self, key, value):
+        self._extra_headers += [ (key,value) ]
+    def make_connection(self, host):
+        # Python 2.4 compatibility
+        if sys.version_info[0] <= 2 and sys.version_info[1] < 7:
+            return UDSHTTP(host)
+        else:
+            return UDSHTTPConnection(host)
+    def send_request(self, connection, handler, request_body):
+        connection.putrequest("POST", handler)
+        for key, value in self._extra_headers:
+            connection.putheader(key, value)
+
+class Session(xmlrpclib.ServerProxy):
+    """A server proxy and session manager for communicating with xapi using
+    the Xen-API.
+
+    Example:
+
+    session = Session('http://localhost/')
+    session.login_with_password('me', 'mypassword', '1.0', 'xen-api-scripts-xenapi.py')
+    session.xenapi.VM.start(vm_uuid)
+    session.xenapi.session.logout()
+    """
+
+    def __init__(self, uri, transport=None, encoding=None, verbose=0,
+                 allow_none=1, ignore_ssl=False):
+
+        # Fix for CA-172901 (+ Python 2.4 compatibility)
+        # Fix for context=ctx ( < Python 2.7.9 compatibility)
+        if not (sys.version_info[0] <= 2 and sys.version_info[1] <= 7 and sys.version_info[2] <= 9 ) \
+                and ignore_ssl:
+            import ssl
+            ctx = ssl._create_unverified_context()
+            xmlrpclib.ServerProxy.__init__(self, uri, transport, encoding,
+                                           verbose, allow_none, context=ctx)
+        else:
+            xmlrpclib.ServerProxy.__init__(self, uri, transport, encoding,
+                                           verbose, allow_none)
+        self.transport = transport
+        self._session = None
+        self.last_login_method = None
+        self.last_login_params = None
+        self.API_version = API_VERSION_1_1
+
+
+    def xenapi_request(self, methodname, params):
+        if methodname.startswith('login'):
+            self._login(methodname, params)
+            return None
+        elif methodname == 'logout' or methodname == 'session.logout':
+            self._logout()
+            return None
+        else:
+            retry_count = 0
+            while retry_count < 3:
+                full_params = (self._session,) + params
+                result = _parse_result(getattr(self, methodname)(*full_params))
+                if result is _RECONNECT_AND_RETRY:
+                    retry_count += 1
+                    if self.last_login_method:
+                        self._login(self.last_login_method,
+                                    self.last_login_params)
+                    else:
+                        raise xmlrpclib.Fault(401, 'You must log in')
+                else:
+                    return result
+            raise xmlrpclib.Fault(
+                500, 'Tried 3 times to get a valid session, but failed')
+
+    def _login(self, method, params):
+        try:
+            result = _parse_result(
+                getattr(self, 'session.%s' % method)(*params))
+            if result is _RECONNECT_AND_RETRY:
+                raise xmlrpclib.Fault(
+                    500, 'Received SESSION_INVALID when logging in')
+            self._session = result
+            self.last_login_method = method
+            self.last_login_params = params
+            self.API_version = self._get_api_version()
+        except socket.error as e:
+            if e.errno == socket.errno.ETIMEDOUT:
+                raise xmlrpclib.Fault(504, 'The connection timed out')
+            else:
+                raise e
+
+    def _logout(self):
+        try:
+            if self.last_login_method.startswith("slave_local"):
+                return _parse_result(self.session.local_logout(self._session))
+            else:
+                return _parse_result(self.session.logout(self._session))
+        finally:
+            self._session = None
+            self.last_login_method = None
+            self.last_login_params = None
+            self.API_version = API_VERSION_1_1
+
+    def _get_api_version(self):
+        pool = self.xenapi.pool.get_all()[0]
+        host = self.xenapi.pool.get_master(pool)
+        major = self.xenapi.host.get_API_version_major(host)
+        minor = self.xenapi.host.get_API_version_minor(host)
+        return "%s.%s"%(major,minor)
+
+    def __getattr__(self, name):
+        if name == 'handle':
+            return self._session
+        elif name == 'xenapi':
+            return _Dispatcher(self.API_version, self.xenapi_request, None)
+        elif name.startswith('login') or name.startswith('slave_local'):
+            return lambda *params: self._login(name, params)
+        elif name == 'logout':
+            return _Dispatcher(self.API_version, self.xenapi_request, "logout")
+        else:
+            return xmlrpclib.ServerProxy.__getattr__(self, name)
+
+def xapi_local():
+    return Session("http://_var_lib_xcp_xapi/", transport=UDSTransport())
+
+def _parse_result(result):
+    if type(result) != dict or 'Status' not in result:
+        raise xmlrpclib.Fault(500, 'Missing Status in response from server' + result)
+    if result['Status'] == 'Success':
+        if 'Value' in result:
+            return result['Value']
+        else:
+            raise xmlrpclib.Fault(500,
+                                  'Missing Value in response from server')
+    else:
+        if 'ErrorDescription' in result:
+            if result['ErrorDescription'][0] == 'SESSION_INVALID':
+                return _RECONNECT_AND_RETRY
+            else:
+                raise Failure(result['ErrorDescription'])
+        else:
+            raise xmlrpclib.Fault(
+                500, 'Missing ErrorDescription in response from server')
+
+
+# Based upon _Method from xmlrpclib.
+class _Dispatcher:
+    def __init__(self, API_version, send, name):
+        self.__API_version = API_version
+        self.__send = send
+        self.__name = name
+
+    def __repr__(self):
+        if self.__name:
+            return '<XenAPI._Dispatcher for %s>' % self.__name
+        else:
+            return '<XenAPI._Dispatcher>'
+
+    def __getattr__(self, name):
+        if self.__name is None:
+            return _Dispatcher(self.__API_version, self.__send, name)
+        else:
+            return _Dispatcher(self.__API_version, self.__send, "%s.%s" % (self.__name, name))
+
+    def __call__(self, *args):
+        return self.__send(self.__name, args)

--- a/relops_hardware_controller/api/management/commands/xenapi_reboot.py
+++ b/relops_hardware_controller/api/management/commands/xenapi_reboot.py
@@ -1,0 +1,78 @@
+
+import contextlib
+import logging
+import re
+import subprocess
+import time
+
+import relops_hardware_controller.XenAPI as XenAPI
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand, CommandError
+from django.core.validators import validate_ipv46_address
+
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def xen_session(api_server_uri, username, password):
+    session = XenAPI.Session(uri=api_server_uri)
+    try:
+        session.login_with_password(username, password)
+    except Exception as error:
+        logger.info('Error logging into XenAPI session %s', error)
+
+    try:
+        yield session
+    finally:
+        session.xenapi.session.logout()
+
+
+class Command(BaseCommand):
+    help = 'Reboots a server using snmp to powercycle its PDU.'
+    doc_url = 'https://wiki.xenproject.org/wiki/Shutting_down_a_VM'
+
+    def add_arguments(self, parser):
+        # Positional arguments
+
+        # TODO: validate uuid
+        parser.add_argument(
+            'host_uuid',
+            type=str,
+            help='Xen VM UUID to power cycle.',
+        )
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--delay',
+            dest='delay',
+            default=5,
+            type=int,
+            help='Wait N seconds before turning the power back on.',
+        )
+
+    def handle(self, host_uuid, *args, **options):
+        logger.info("Powercycling %s via XenAPI.", host_uuid)
+
+        with xen_session(settings.XEN_URL,
+                         settings.XEN_USERNAME,
+                         settings.XEN_PASSWORD) as session:
+            vm = session.xenapi.VM.get_by_uuid(host_uuid)
+            logger.debug("Found xen VM %s. powering off.", vm)
+
+            try:
+                session.xenapi.VM.clean_shutdown(vm)
+                logger.debug("clean shutdown of xen VM %s complete.", vm)
+            except Exception as error:
+                logger.debug("Found xen VM %s. powering off.", vm)
+                session.xenapi.VM.hard_shutdown(vm)  # if this fails it raises and error and we logout
+                logger.debug("hard shutdown of xen VM %s complete.", vm)
+
+            logger.debug("Power is off, waiting %d seconds before turning it back on.", options['delay'])
+            time.sleep(options['delay'])
+
+            session.xenapi.VM.start(vm, False, False)
+            logger.info("Powercycle of %s completed.", host_uuid)
+            # TODO: poll for VM_guest_metrics?

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -154,6 +154,10 @@ class Base(Configuration):
     BUGZILLA_URL = values.URLValue()
     BUGZILLA_API_KEY = values.SecretValue()
 
+    XEN_URL = values.URLValue()
+    XEN_USERNAME = values.Value()
+    XEN_PASSWORD = values.SecretValue()
+
     REST_FRAMEWORK = {
         'DEFAULT_RENDERER_CLASSES': (
             'rest_framework.renderers.JSONRenderer',
@@ -185,6 +189,9 @@ class Dev(Base):
 
     BUGZILLA_URL = 'https://landfill.bugzilla.org/bugzilla-5.0-branch/rest/'
 
+    XEN_URL = 'https://xenapiserver/'
+    XEN_USERNAME = 'xen_dev_username'
+
 
 class Prod(Base):
     ALLOWED_HOSTS = ['tools.taskcluster.net']
@@ -198,3 +205,7 @@ class Test(Base):
     CORS_ORIGIN = 'localhost'
 
     SECRET_KEY = values.Value('not-so-secret-after-all')
+
+    XEN_URL = 'https://xenapiserver/'
+    XEN_USERNAME = 'xen_dev_username'
+    XEN_PASSWORD = values.Value('not-so-secret-after-all')

--- a/tests/test_xenapi_reboot.py
+++ b/tests/test_xenapi_reboot.py
@@ -1,0 +1,108 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import subprocess
+
+import mock
+import pytest
+
+from django.core.exceptions import ValidationError
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.xenapi_reboot
+@pytest.mark.parametrize(
+    "args", [
+        [
+        ],
+    ], ids=['host_uuid']
+)
+def test_xenapi_reboot_requires_arg(args):
+    with pytest.raises(CommandError):
+        call_command('xenapi_reboot', *args)
+
+
+# TODO: test invalid args
+
+
+@pytest.mark.xenapi_reboot
+def test_xenapi_reboot_login_failure():
+    with mock.patch('relops_hardware_controller.api.management.commands.xenapi_reboot.XenAPI.Session') as mock_session_ctor:
+        mock_session = mock_session_ctor.return_value
+
+        mock_session.login_with_password.side_effect = Exception("XenAPI login failed.")
+
+        call_command('xenapi_reboot', 'test_xen_vm_uuid', delay=1)
+
+        mock_session_ctor.assert_called_once_with(uri='https://xenapiserver/')
+
+        mock_session.login_with_password.assert_called_once_with('xen_dev_username', 'anything_zen_password')
+
+        mock_session.xenapi.session.logout.assert_called_once_with()
+
+
+@pytest.mark.xenapi_reboot
+def test_xenapi_soft_reboot_success():
+    with mock.patch('relops_hardware_controller.api.management.commands.xenapi_reboot.XenAPI.Session') as mock_session_ctor:
+        mock_session = mock_session_ctor.return_value
+        mock_vm = mock_session.xenapi.VM.get_by_uuid.return_value
+
+        call_command('xenapi_reboot', 'test_xen_vm_uuid', delay=1)
+
+        mock_session_ctor.assert_called_once_with(uri='https://xenapiserver/')
+
+        mock_session.login_with_password.assert_called_once_with('xen_dev_username', 'anything_zen_password')
+
+        mock_session.xenapi.VM.get_by_uuid.assert_called_once_with('test_xen_vm_uuid')
+        mock_session.xenapi.VM.clean_shutdown.assert_called_once_with(mock_vm)
+
+        mock_session.xenapi.VM.start.assert_called_once_with(mock_vm, False, False)
+
+        mock_session.xenapi.session.logout.assert_called_once_with()
+
+
+@pytest.mark.xenapi_reboot
+def test_xenapi_hard_reboot_success():
+    with mock.patch('relops_hardware_controller.api.management.commands.xenapi_reboot.XenAPI.Session') as mock_session_ctor:
+        mock_session = mock_session_ctor.return_value
+        mock_vm = mock_session.xenapi.VM.get_by_uuid.return_value
+
+        mock_session.xenapi.VM.clean_shutdown.side_effect = Exception("XenAPI clean shutdown failed.")
+
+        call_command('xenapi_reboot', 'test_xen_vm_uuid', delay=1)
+
+        mock_session_ctor.assert_called_once_with(uri='https://xenapiserver/')
+
+        mock_session.login_with_password.assert_called_once_with('xen_dev_username', 'anything_zen_password')
+
+        mock_session.xenapi.VM.get_by_uuid.assert_called_once_with('test_xen_vm_uuid')
+        mock_session.xenapi.VM.clean_shutdown.assert_called_once_with(mock_vm)
+        mock_session.xenapi.VM.hard_shutdown.assert_called_once_with(mock_vm)
+        mock_session.xenapi.VM.start.assert_called_once_with(mock_vm, False, False)
+
+        mock_session.xenapi.session.logout.assert_called_once_with()
+
+
+@pytest.mark.xenapi_reboot
+def test_xenapi_reboot_shutdown_failure():
+    with mock.patch('relops_hardware_controller.api.management.commands.xenapi_reboot.XenAPI.Session') as mock_session_ctor:
+        mock_session = mock_session_ctor.return_value
+        mock_vm = mock_session.xenapi.VM.get_by_uuid.return_value
+
+        mock_session.xenapi.VM.clean_shutdown.side_effect = Exception("XenAPI clean shutdown failed.")
+        mock_session.xenapi.VM.hard_shutdown.side_effect = Exception("XenAPI hard shutdown failed.")
+
+        with pytest.raises(Exception):
+            call_command('xenapi_reboot', 'test_xen_vm_uuid', delay=1)
+
+        mock_session_ctor.assert_called_once_with(uri='https://xenapiserver/')
+
+        mock_session.login_with_password.assert_called_once_with('xen_dev_username', 'anything_zen_password')
+
+        mock_session.xenapi.VM.get_by_uuid.assert_called_once_with('test_xen_vm_uuid')
+        mock_session.xenapi.VM.clean_shutdown.assert_called_once_with(mock_vm)
+        mock_session.xenapi.VM.hard_shutdown.assert_called_once_with(mock_vm)
+
+        mock_session.xenapi.session.logout.assert_called_once_with()


### PR DESCRIPTION
Might need extra translation work to get VM UUIDs and switching to an async task queue if shutdowns are slow and migrating VMs off the hypervisor before shutting down (like the linked shutdown script in #18).

Assuming a newer xenserver  version so the hard shut down work.