### PR TITLE
Push to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           working_directory: ~/roller
           command: |
             cp .env-dist .env
-            make test       
+            make test
 
       - run:
           name: Push container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,18 @@ jobs:
           working_directory: ~/roller
           command: |
             cp .env-dist .env
-            make test
+            make test       
 
+      - run:
+          name: Push container
+          command: |
+             if [ ! -z "${CIRCLE_TAG}" ]; then
+                 docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
+                 docker tag roller:build "DOCKERHUB_REPO:latest"
+                 docker push "DOCKERHUB_REPO:latest"
+                 docker tag roller:build "DOCKERHUB_REPO:$CIRCLE_TAG"
+                 docker push "DOCKERHUB_REPO:$CIRCLE_TAG"
+             fi
 
 workflows:
   version: 2


### PR DESCRIPTION
Upon tagging a release, this will push the roller container over to dockerhub.
Credentials are already configured in circleci.