### PR TITLE
add missing $ signs to $DOCKERHUB_REPO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
              if [ ! -z "${CIRCLE_TAG}" ]; then
                  docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
                  docker tag roller:build "DOCKERHUB_REPO:latest"
-                 docker push "DOCKERHUB_REPO:latest"
-                 docker tag roller:build "DOCKERHUB_REPO:$CIRCLE_TAG"
-                 docker push "DOCKERHUB_REPO:$CIRCLE_TAG"
+                 docker push "$DOCKERHUB_REPO:latest"
+                 docker tag roller:build "$DOCKERHUB_REPO:$CIRCLE_TAG"
+                 docker push "$DOCKERHUB_REPO:$CIRCLE_TAG"
              fi
 
 workflows:


### PR DESCRIPTION
should fix "Error parsing reference: "DOCKERHUB_REPO:latest" is not a valid repository/tag: invalid reference format: repository name must be lowercase"