### PR TITLE
remove unused taskresult serializer

### DIFF
--- a/relops_hardware_controller/api/serializers.py
+++ b/relops_hardware_controller/api/serializers.py
@@ -3,14 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django_celery_results.models import TaskResult
 from rest_framework import serializers
-
-
-class TaskResultSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = TaskResult
-        fields = ('task_id', 'status', 'date_done', 'result')
 
 
 class JobSerializer(serializers.Serializer):


### PR DESCRIPTION
This is dead code originally intended for returning Celery task results via the API or for reporting.

It might be useful for that later, but can be removed for now. 

Tests are passing.

r? @davehouse 